### PR TITLE
More bug fixes to make the card-editor work as expected

### DIFF
--- a/homeassistant/components/quotable/services.py
+++ b/homeassistant/components/quotable/services.py
@@ -193,9 +193,12 @@ async def _fetch_a_quote_service(
     if quotable is None:
         return None
 
+    selected_tags = quotable.config.get(ATTR_SELECTED_TAGS, [])
+    selected_authors = quotable.config.get(ATTR_SELECTED_AUTHORS, [])
+
     params = {
-        "tags": "|".join(quotable.config.get(ATTR_SELECTED_TAGS, [])),
-        "author": "|".join(quotable.config.get(ATTR_SELECTED_AUTHORS, [])),
+        "tags": "|".join(tag[ATTR_SLUG] for tag in selected_tags),
+        "author": "|".join(author[ATTR_SLUG] for author in selected_authors),
     }
 
     try:


### PR DESCRIPTION
Fixes the following bugs:
- the interval slider value is not sent to update_configuration service in the backend
- the clickable list of selected authors/tags has been removed by newer PR’s, restore it back
- the intial values for the configuration are not set from the hass.state